### PR TITLE
Get 100% coverage by removing impossible try/catch

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -5,7 +5,6 @@ use ArrayObject;
 use JsonSerializable;
 use TypeError;
 use ReflectionClass;
-use ReflectionException;
 
 /**
  * Managur Generic Collection Class

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -345,11 +345,7 @@ class Collection extends ArrayObject implements JsonSerializable
      */
     private function getNewInstance($data): self
     {
-        try {
-            $reflection = new ReflectionClass($this);
-        } catch (ReflectionException $e) {
-            throw new TypeError('Error reflecting collection', null, $e);
-        }
+        $reflection = new ReflectionClass($this);
         if ($reflection->isAnonymous()) {
             return self::getTypedCollection($data, $this->keyType, $this->valueType);
         }


### PR DESCRIPTION
`ReflectionException` will only be thrown if the given class does not exist. If an instance is passed to `ReflectionClass`, the class will always exist, so `ReflectionException` will never be thrown here.