### PR TITLE
fix: return type of implode method

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -422,7 +422,7 @@ class Collection extends ArrayObject implements JsonSerializable
      *
      * @param string $glue
      * @param callable $callable
-     * @return static
+     * @return string
      */
     public function implode($glue = '', callable $callable = null): string
     {


### PR DESCRIPTION
Return type is string, but docblock was incorrect listing it as static.
As such, psalm complained that my return type of string of a function
that called implode wasn't correct with what it actually returned.